### PR TITLE
Changed type for 'createstamp' and 'updatestamp' from int to long

### DIFF
--- a/xsd/resource.xsd
+++ b/xsd/resource.xsd
@@ -31,8 +31,8 @@
                   <xs:attribute name="type" type="xs:string" use="required"/>
                   <xs:attribute name="label" type="xs:string" use="optional"/>
                   <xs:attribute name="uuid" type="xs:string" use="optional"/>
-                  <xs:attribute name="createstamp" type="xs:int" use="optional"/>
-                  <xs:attribute name="updatestamp" type="xs:int" use="optional"/>
+                  <xs:attribute name="createstamp" type="xs:long" use="optional"/>
+                  <xs:attribute name="updatestamp" type="xs:long" use="optional"/>
                 </xs:complexType>
               </xs:element>
             </xs:sequence>


### PR DESCRIPTION
In order to facilitate Unix timestamps the type of  'createstamp' and 'updatestamp' has changed from int to long.