### PR TITLE
Add optional "attachments" elem to resource schema.

### DIFF
--- a/xsd/resource.xsd
+++ b/xsd/resource.xsd
@@ -41,6 +41,24 @@
             </xs:sequence>
           </xs:complexType>
         </xs:element>
+        <xs:choice minOccurs="0" maxOccurs="1">
+          <xs:element name="attachments">
+            <xs:complexType>
+              <xs:choice minOccurs="1" maxOccurs="65536">
+                <xs:element name="attachment">
+                  <xs:complexType>
+                    <xs:attribute name="id" type="xs:integer"  use="required"/>
+                    <xs:attribute name="mimeType" type="xs:string" use="optional"/>
+                  </xs:complexType>
+                </xs:element>
+              </xs:choice>
+            </xs:complexType>
+            <xs:unique name="unique-attachmentId">
+              <xs:selector xpath="attachment"/>
+              <xs:field xpath="@id"/>
+            </xs:unique>
+          </xs:element>
+        </xs:choice>
       </xs:sequence>
       <xs:attribute name="type" type="xs:string" use="required"/>
     </xs:complexType>


### PR DESCRIPTION
This is the proposed extension to the resource schema, allowing for attachments. Featuring:-

- `attachments` elem is optional; this change is therefore backward compatible
- up to 65536 `attachment` elems are allowed in `attachments`
- each `attachment`must have a unique integer `id` attr.

An example of a valid resource:-

    <?xml version="1.0" encoding="UTF-8"?>
    <resource type="hub/dossier">
      <sections>
        <section type="client" id="1" createStamp="2016-12-01">
          <values>
            <value concept="foo" value="bar"/>
          </values>
        </section>
      </sections>
      <attachments>
        <attachment id="1" mimeType="appliaction/pdf"/>
        <attachment id="2"/>
      </attachments>
    </resource>