### PR TITLE
More to do for Diagnosis and Conclusion concepts

### DIFF
--- a/sectionTypes/echo.xml
+++ b/sectionTypes/echo.xml
@@ -121,4 +121,7 @@
   <field concept="peri22-dataelement-82311" min="0" max="1" note="crl" />
   <field concept="peri22-dataelement-82312" min="0" max="1" note="bpd" />
   <field concept="peri22-dataelement-82227" min="0" max="1" note="invasieve prenatale diagnostiek" />
+
+  <field concept="peri22x-echo-conclusie" min="0" max="1" note="conclusie gemaakt na echografie" />
+  <field concept="peri22x-echo-diagnose" min="0" max="1" note="diagnose gemaakt na echografie" />
 </sectionType>

--- a/xsd/resource.xsd
+++ b/xsd/resource.xsd
@@ -17,7 +17,7 @@
                               <xs:simpleContent>
                                 <xs:extension base="xs:string">
                                   <xs:attribute name="label" type="xs:string" use="optional"/>
-                                  <xs:attribute name="value" type="xs:string" use="required"/>
+                                  <xs:attribute name="value" type="xs:string" use="optional"/>
                                   <xs:attribute name="displayValue" type="xs:string" use="optional"/>
                                   <xs:attribute name="keyId" type="xs:string" use="optional"/>
                                   <xs:attribute name="concept" type="xs:string" use="required"/>

--- a/xsd/resource.xsd
+++ b/xsd/resource.xsd
@@ -14,15 +14,17 @@
                         <xs:sequence>
                           <xs:element name="value" maxOccurs="unbounded">
                             <xs:complexType>
-                              <xs:sequence>
-                              </xs:sequence>
-                              <xs:attribute name="label" type="xs:string" use="optional"/>
-                              <xs:attribute name="value" type="xs:string" use="required"/>
-                              <xs:attribute name="displayValue" type="xs:string" use="optional"/>
-                              <xs:attribute name="keyId" type="xs:string" use="optional"/>
-                              <xs:attribute name="concept" type="xs:string" use="required"/>
-                              <xs:attribute name="repeat" type="xs:integer" use="optional"/>
-                              <xs:attribute name="group" type="xs:integer" use="optional"/>
+                              <xs:simpleContent>
+                                <xs:extension base="xs:string">
+                                  <xs:attribute name="label" type="xs:string" use="optional"/>
+                                  <xs:attribute name="value" type="xs:string" use="required"/>
+                                  <xs:attribute name="displayValue" type="xs:string" use="optional"/>
+                                  <xs:attribute name="keyId" type="xs:string" use="optional"/>
+                                  <xs:attribute name="concept" type="xs:string" use="required"/>
+                                  <xs:attribute name="repeat" type="xs:integer" use="optional"/>
+                                  <xs:attribute name="group" type="xs:integer" use="optional"/>
+                                </xs:extension>
+                              </xs:simpleContent>
                             </xs:complexType>
                           </xs:element>
                         </xs:sequence>


### PR DESCRIPTION
-  Add diagnosis and conclusion concepts to echo section

-  change the XSD to allow echo "value" elements to have string content, e.g.

        <value concept="..." value=""><![CDATA[some text with newlines]]></value>

- the value attr of the value element is now optional to allow the attribute or the content to provide the value of the concept